### PR TITLE
Updated method definition for Phaser.Group.AddAll() - phaser.d.ts

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1770,7 +1770,7 @@ declare module Phaser {
         z: number;
 
         add(child: any, silent?: boolean, index?: number): any;
-        addAll(property: string, amount: number, checkAlive: boolean, checkVisible: boolean): void;
+        addAll(property: string, amount: number, checkAlive?: boolean, checkVisible?: boolean): void;
         addAt(child: any, index: number, silent?: boolean): any;
         addMultiple(children: any[], silent?: boolean): any[];
         addToHash(child: PIXI.DisplayObject): boolean;


### PR DESCRIPTION
This PR changes : TypeScript Defs

Describe the changes below:
As mentioned in post [issue#45](https://github.com/photonstorm/phaser-ce/issues/45) , these two parameters (`checkAlive:boolean, checkVisible:boolean`) should be optional,, in case they're not provided when calling the method , they're implicitly set to `false `anyway while calling `Phaser.Group.setAll()` method afterwards.
